### PR TITLE
[宿題] データを削除するときに、確認ダイアログを表示する + リストにデータを追加するときに年数も追加できるようにする

### DIFF
--- a/lib/add_page.dart
+++ b/lib/add_page.dart
@@ -1,9 +1,8 @@
-import 'dart:ffi';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+// ignore: must_be_immutable
 class AddPage extends StatelessWidget {
   AddPage({Key? key}) : super(key: key);
 
@@ -11,34 +10,62 @@ class AddPage extends StatelessWidget {
   String last = "";
   int born = 0;
 
+  final _formKey = GlobalKey<FormState>();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
       body: Padding(
         padding: const EdgeInsets.all(8.0),
-        child: Column(
-          children: [
-            TextField(
-              decoration: const InputDecoration(
-                hintText: 'First',
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                decoration: const InputDecoration(
+                  hintText: 'First',
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'First Name（名）を入力してください';
+                  }
+                  return null;
+                },
+                onChanged: (text) {
+                  first = text;
+                },
               ),
-              onChanged: (text) {
-                first = text;
-              },
-            ),
-            TextField(
-              decoration: const InputDecoration(
-                hintText: 'Last',
+              TextFormField(
+                decoration: const InputDecoration(
+                  hintText: 'Last',
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Last Name（姓）を入力してください';
+                  }
+                  return null;
+                },
+                onChanged: (text) {
+                  last = text;
+                },
               ),
-              onChanged: (text) {
-                last = text;
-              },
-            ),
-            TextField(
+              TextFormField(
                 decoration: const InputDecoration(
                   hintText: '1990',
                 ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '生まれた年を入力してください';
+                  }
+                  if (value.length != 4) {
+                    return '4桁の西暦で入力してください';
+                  }
+                  if (int.parse(value) > DateTime.now().year ) {
+                    return '過去の年で入力してください';
+                  }
+                  return null;
+                },
                 keyboardType: TextInputType.number,
                 inputFormatters: [
                   LengthLimitingTextInputFormatter(4),
@@ -47,15 +74,23 @@ class AddPage extends StatelessWidget {
                 onChanged: (text) {
                   born = int.parse(text);
                 },
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                await _addToFirebase();
-                Navigator.pop(context);
-              },
-              child: Text("Add to Firebase"),
-            ),
-          ],
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () async {
+                  if (_formKey.currentState!.validate()) {
+                    await _addToFirebase();
+                    // ignore: use_build_context_synchronously
+                    Navigator.pop(context);
+                    // ScaffoldMessenger.of(context).showSnackBar(
+                    //   const SnackBar(content: Text('更新しました')),
+                    // );
+                  }
+                },
+                child: Text("Add to Firebase"),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/add_page.dart
+++ b/lib/add_page.dart
@@ -1,11 +1,15 @@
+import 'dart:ffi';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class AddPage extends StatelessWidget {
   AddPage({Key? key}) : super(key: key);
 
   String first = "";
   String last = "";
+  int born = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +35,19 @@ class AddPage extends StatelessWidget {
                 last = text;
               },
             ),
+            TextField(
+                decoration: const InputDecoration(
+                  hintText: '1990',
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [
+                  LengthLimitingTextInputFormatter(4),
+                  FilteringTextInputFormatter.digitsOnly,
+                ],
+                onChanged: (text) {
+                  born = int.parse(text);
+                },
+            ),
             ElevatedButton(
               onPressed: () async {
                 await _addToFirebase();
@@ -50,7 +67,7 @@ class AddPage extends StatelessWidget {
     final user = <String, dynamic>{
       "first": first,
       "last": last,
-      "born": 1991,
+      "born": born,
     };
 
 // Add a new document with a generated ID

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 context: context,
                 builder: (BuildContext context) {
                   return AlertDialog(
-                    title: Text("Select Year"),
+                    title: const Text("Select Year"),
                     content: Container(
                       width: 300,
                       height: 300,
@@ -97,7 +97,6 @@ class _MyHomePageState extends State<MyHomePage> {
                           });
 
                           Navigator.pop(context);
-
                           _fetchFirebaseData();
                         },
                       ),
@@ -106,10 +105,47 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
               );
             },
-            onLongPress: () async {
-              final db = FirebaseFirestore.instance;
-              await db.collection("users").doc(user.id).delete();
-              _fetchFirebaseData();
+            // onLongPress: () async {
+            //   final db = FirebaseFirestore.instance;
+            //   await db.collection("users").doc(user.id).delete();
+            //   _fetchFirebaseData();
+            // },
+            onLongPress: () {
+              showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                    title: const Text('本当に削除しますか？'),
+                    content: const SizedBox(
+                      height: 5,
+                    ),
+                    actions: <Widget>[
+                      GestureDetector(
+                        child: const Text('いいえ'),
+                        onTap: () {
+                          Navigator.pop(context);
+                        },
+                      ),
+                      const SizedBox(
+                        width: 20,
+                      ),
+                      GestureDetector(
+                        child: const Text('はい'),
+                        onTap: () {
+                          final db = FirebaseFirestore.instance;
+                          db.collection("users").doc(user.id).delete();
+
+                          Navigator.pop(context);
+                          _fetchFirebaseData();
+                        },
+                      ),
+                      const SizedBox(
+                        width: 10,
+                      ),
+                    ],
+                  );
+                },
+              );
             },
           );
         }).toList(),


### PR DESCRIPTION
**1. データを削除するときに、確認ダイアログを表示する**

![スクリーンショット 2023-10-10 15 37 44](https://github.com/uni51/flu_textbook_v2_firebase_bookmark/assets/14168897/34ea49e2-e475-44e0-967c-6b6c07ea70fe)

**2. リストにデータを追加するときに年数も追加できるようにする**

![スクリーンショット 2023-10-08 6 15 04](https://github.com/uni51/flu_textbook_v2_firebase_bookmark/assets/14168897/9ec26705-8ab4-40a7-84f8-c2a07136260a)


**工夫したところ**

- 「2. リストにデータを追加するときに年数も追加できるようにする」において、数値しか入力できないように制限をかけたのと、簡易的なバリデーションを付与してみました。

![スクリーンショット 2023-10-08 6 56 36](https://github.com/uni51/flu_textbook_v2_firebase_bookmark/assets/14168897/c7f9511b-1efc-4fc4-baea-f24617213326)


参考：
- https://qiita.com/beckyJPN/items/912cb61cfee813bf4a70 （数値しか入力できないように制限をかける）
- https://zenn.dev/monkeydaichan/articles/14133cb66c0682  （簡易的なバリデーションの実装）
